### PR TITLE
Deprecate in favor of cargo-hack's --workspace-behavior=cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+**This crate is now deprecated in favor of more powerful `cargo hack --workspace-behavior=cargo --no-dev-deps` added in cargo-hack 0.6.44.**
+
 ## [0.2.23] - 2026-03-20
 
 - Publish [artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["cargo", "subcommand", "testing"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools::testing"]
 exclude = ["/.*", "/tools"]
 description = """
-Cargo subcommand for running cargo without dev-dependencies.
+Cargo subcommand for running cargo without dev-dependencies. (deprecated)
 """
 
 [package.metadata.docs.rs]
@@ -21,6 +21,9 @@ disabled-strategies = ["quick-install"]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [dependencies]
 anyhow = "1.0.47"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![crates.io](https://img.shields.io/crates/v/cargo-no-dev-deps?style=flat-square&logo=rust)](https://crates.io/crates/cargo-no-dev-deps)
 [![license](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue?style=flat-square)](#license)
 [![github actions](https://img.shields.io/github/actions/workflow/status/taiki-e/cargo-no-dev-deps/ci.yml?branch=main&style=flat-square&logo=github)](https://github.com/taiki-e/cargo-no-dev-deps/actions)
+![maintenance-status](https://img.shields.io/badge/maintenance-deprecated-red?style=flat-square)
+
+**Note: This crate is now deprecated in favor of more powerful `cargo hack --workspace-behavior=cargo --no-dev-deps` added in cargo-hack 0.6.44.**
 
 Cargo subcommand for running cargo without dev-dependencies.
 
@@ -55,7 +58,7 @@ If you want exclude `publish = false` crates, you can exclude these crates by us
 cargo no-dev-deps --no-private check
 ```
 
-This flag is more powerful than [cargo-hack's `--ignore-private` flag](https://github.com/taiki-e/cargo-hack#--ignore-private), because this also prevents private crates from affecting lockfile and metadata.
+This flag is more powerful than [cargo-hack's `--ignore-private` flag](https://github.com/taiki-e/cargo-hack#--ignore-private), because this also prevents private crates from affecting lockfile and metadata. (cargo-hack also supports `--no-private` flag.)
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,12 @@ fn main() -> ExitCode {
 
 fn try_main() -> Result<()> {
     let Some(args) = Args::parse()? else { return Ok(()) };
+    {
+        let _guard = term::warn::scoped(false);
+        warn!(
+            "cargo-no-dev-deps is now deprecated in favor of more powerful `cargo hack --workspace-behavior=cargo --no-dev-deps` added in cargo-hack 0.6.44"
+        );
+    }
     let ws = Workspace::new(args.manifest_path.as_deref())?;
 
     let no_dev_deps = true;

--- a/src/term.rs
+++ b/src/term.rs
@@ -88,6 +88,18 @@ macro_rules! global_flag {
             pub(crate) fn set(value: $value) {
                 VALUE.store(value, Ordering::Relaxed);
             }
+            pub(crate) struct Guard {
+                prev: $value,
+            }
+            impl Drop for Guard {
+                fn drop(&mut self) {
+                    set(self.prev);
+                }
+            }
+            #[allow(dead_code)]
+            pub(crate) fn scoped(value: $value) -> Guard {
+                Guard { prev: VALUE.swap(value, Ordering::Relaxed) }
+            }
         }
         pub(crate) fn $name() -> $value {
             $name::VALUE.load(Ordering::Relaxed)
@@ -118,14 +130,14 @@ macro_rules! error {
     }};
 }
 
-// macro_rules! warn {
-//     ($($msg:expr),* $(,)?) => {{
-//         use std::io::Write as _;
-//         crate::term::warn::set(true);
-//         let mut stream = crate::term::print_status("warning", Some(termcolor::Color::Yellow));
-//         let _ = writeln!(stream, $($msg),*);
-//     }};
-// }
+macro_rules! warn {
+    ($($msg:expr),* $(,)?) => {{
+        use std::io::Write as _;
+        crate::term::warn::set(true);
+        let mut stream = crate::term::print_status("warning", Some(termcolor::Color::Yellow));
+        let _ = writeln!(stream, $($msg),*);
+    }};
+}
 
 macro_rules! info {
     ($($msg:expr),* $(,)?) => {{


### PR DESCRIPTION

This crate is now deprecated in favor of more powerful `cargo hack --workspace-behavior=cargo --no-dev-deps` added in cargo-hack 0.6.45.

Closes #13 
